### PR TITLE
Update build workflow to use submodules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,42 +75,18 @@ jobs:
         python -m pip install wheel
         pip install git+https://github.com/alliedmodders/ambuild
 
-    - name: Fetch Metamod:Source ${{ matrix.meta_branch }}
-      uses: actions/checkout@v4
-      with:
-        repository: alliedmodders/metamod-source
-        ref: ${{ matrix.meta_branch }}
-        path: mmsource
-
-    - name: Fetch SourceMod ${{ matrix.sm_branch }}
-      uses: actions/checkout@v4
-      with:
-        repository: alliedmodders/sourcemod
-        ref: ${{ matrix.sm_branch }}
-        path: sourcemod
-        submodules: recursive
-
-    - name: Fetch SDKs
-      shell: bash
-      run: |
-        git clone --mirror https://github.com/alliedmodders/hl2sdk hl2sdk-proxy-repo
-        sdks=(tf2 css hl2dm dods bms sdk2013)
-        for sdk in "${sdks[@]}"
-        do
-          git clone hl2sdk-proxy-repo -b $sdk hl2sdk-$sdk
-        done
-
     - name: Fetch RCBot2
       uses: actions/checkout@v4
       with:
         path: rcbot2
+        submodules: recursive
 
     - name: Build Files
       working-directory: rcbot2
       run: |
         mkdir post
         cd post
-        python3 ../configure.py --sdks=present --sm-path="${{ github.workspace }}/sourcemod" --mms-path="${{ github.workspace }}/mmsource" --symbol-files
+        python3 ../configure.py --sdks=present --mms-path="${{ github.workspace }}/rcbot2/alliedmodders/metamod-source" --sm-path="${{ github.workspace }}/rcbot2/alliedmodders/sourcemod" --hl2sdk-root="${{ github.workspace }}/rcbot2/alliedmodders" --symbol-files
         ambuild
 
     - uses: benjlevesque/short-sha@v2.2


### PR DESCRIPTION
The build process doesn't need is to pull in all the Alliedmodders stuff separately anymore, we want git to pull them in as sub-modules - then the SdkHelpers.ambuild file directory will be where ambuild expects it to be

https://github.com/matthewmelvin/rcbot2/actions/runs/17487589633/job/49669854493#step:7:95